### PR TITLE
fix:live_extract

### DIFF
--- a/ovos_ocp_youtube_plugin/__init__.py
+++ b/ovos_ocp_youtube_plugin/__init__.py
@@ -4,8 +4,8 @@ import json
 import requests
 from ovos_plugin_manager.templates.ocp import OCPStreamExtractor
 from ovos_utils.log import LOG
-from pytube import YouTube
 from tutubo.models import Channel
+from tutubo.pytube import YouTube
 
 
 class YoutubeBackend(str, enum.Enum):
@@ -41,6 +41,10 @@ class OCPYoutubeExtractor(OCPStreamExtractor):
         cls.pytube = OCPPytubeExtractor()
         cls.invidious = OCPInvidiousExtractor()
 
+    @staticmethod
+    def is_ytmus(uri):
+        return "music.youtube" in uri
+
     def __init__(self, ocp_settings=None):
         super().__init__(ocp_settings)
         self.settings = self.ocp_settings.get("youtube", {})
@@ -65,7 +69,7 @@ class OCPYoutubeExtractor(OCPStreamExtractor):
     def validate_uri(self, uri):
         """ return True if uri can be handled by this extractor, False otherwise"""
         return any([uri.startswith(sei) for sei in self.supported_seis]) or \
-               self.is_youtube(uri)
+            self.is_youtube(uri)
 
     def extract_stream(self, uri, video=True):
         """ return the real uri that can be played by OCP """
@@ -133,8 +137,10 @@ class OCPYDLExtractor(OCPYoutubeExtractor):
         """
         return ["ydl"]
 
-    def extract_stream(self, uri, video=True):
+    def extract_stream(self, uri, video=None):
         """ return the real uri that can be played by OCP """
+        if video is None:
+            video = not OCPYoutubeExtractor.is_ytmus(u)
         if uri.startswith("ydl//"):
             uri = uri.replace("ydl//", "")
         meta = self.get_ydl_stream(uri, audio_only=not video)
@@ -237,9 +243,9 @@ class OCPYoutubeChannelLiveExtractor(OCPYoutubeExtractor):
 
     @staticmethod
     def get_pytube_channel_livestreams(url):
-        yt = Channel(url)
-        for v in yt.videos_generator():
-            if v.vid_info.get('playabilityStatus', {}).get('liveStreamability'):
+        c = Channel(url)
+        for v in c.live:
+            if v.is_live:
                 title, artist = OCPYoutubeExtractor.parse_title(v.title)
                 yield {
                     "url": v.watch_url,

--- a/ovos_ocp_youtube_plugin/__init__.py
+++ b/ovos_ocp_youtube_plugin/__init__.py
@@ -140,7 +140,7 @@ class OCPYDLExtractor(OCPYoutubeExtractor):
     def extract_stream(self, uri, video=None):
         """ return the real uri that can be played by OCP """
         if video is None:
-            video = not OCPYoutubeExtractor.is_ytmus(u)
+            video = not OCPYoutubeExtractor.is_ytmus(uri)
         if uri.startswith("ydl//"):
             uri = uri.replace("ydl//", "")
         meta = self.get_ydl_stream(uri, audio_only=not video)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-plugin-manager>=0.0.1,<1.0.0
+tutubo>=2.0.2,<3.0.0
 yt-dlp
-tutubo


### PR DESCRIPTION
feat:prefer_audio_streams by default for youtube music
fix:live_stream_extract

pytube is abandoned, fully move to tutubo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to identify YouTube Music URIs, enhancing content handling.
	- Updated stream extraction logic to better differentiate between video and music streams.

- **Bug Fixes**
	- Improved the retrieval of live streams by utilizing a more efficient property check.

- **Chores**
	- Updated dependency specifications for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->