### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
-# OCP Youtube Plugin
+# OCP YouTube Plugin
 
-allows OCP to play youtube urls
+This plugin lets OVOS Common Play (OCP) play YouTube URLs. It extracts a
+playable stream from a YouTube link, channel, or live broadcast, so OCP can
+hand it to an audio or video player.
+
+## Install
+
+```bash
+pip install ovos-ocp-youtube-plugin
+```
+
+The plugin registers itself as an OCP stream extractor through the
+`opm.ocp.extractor` entry point. OCP loads it automatically once it is
+installed. No extra setup is needed.
+
+## Usage
+
+OCP calls this plugin when it meets a URI that starts with one of these
+prefixes:
+
+- `youtube`: a YouTube video or playlist URL
+- `ydl`: any URL that yt-dlp can resolve
+- `youtube.channel.live`: a channel's current live stream
+- `pytube`: force the pytube backend
+- `invidious`: force an Invidious instance
+
+Configure the extractor under the `OCP` section of `mycroft.conf`:
+
+```json
+{
+  "OCP": {
+    "youtube": {
+      "youtube_backend": "youtube-dl",
+      "youtube_live_backend": "redirect",
+      "ydl_backend": "yt-dlp"
+    }
+  }
+}
+```
+
+- `youtube_backend` selects the extraction method: `youtube-dl`, `pytube`,
+  `invidious`, or `webview`.
+- `youtube_live_backend` selects how a channel live stream resolves:
+  `redirect`, `youtube-dl`, or `pytube`.
+- `ydl_backend` selects the youtube-dl fork used: `youtube-dl`,
+  `youtube-dlc`, `yt-dlp`, or `auto`.
+
+## Related projects
+
+- [OpenVoiceOS/ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): loads and manages OCP stream extractor plugins.
+- [OpenVoiceOS/ovos-ocp-audio-plugin](https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin): a sibling OCP stream extractor plugin.
+- [OpenVoiceOS/ovos-media](https://github.com/OpenVoiceOS/ovos-media): the media service that plays streams resolved by OCP extractors.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README for clarity: expands the one-line description into a
usable README with an install step, a usage section covering the supported
URI prefixes and `mycroft.conf` settings, and links to related OpenVoiceOS
projects. Every fact was verified against the plugin source.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with installation and configuration guidance.
  * Documented automatic extractor registration and supported URI prefixes.
  * Added information about related projects and the Apache-2.0 license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->