### PR TITLE
fix: lazy tutubo.pytube import so tutubo>=3 doesn't break the whole plugin

### DIFF
--- a/ovos_ocp_youtube_plugin/__init__.py
+++ b/ovos_ocp_youtube_plugin/__init__.py
@@ -6,7 +6,16 @@ import requests
 from ovos_plugin_manager.templates.ocp import OCPStreamExtractor
 from ovos_utils.log import LOG
 from tutubo.models import Channel
-from tutubo.pytube import YouTube
+try:
+    # tutubo>=3.0.0 rewrote the internals around a new innertube-based API
+    # and dropped the `tutubo.pytube` submodule entirely. Import it lazily
+    # so simply having a newer tutubo installed does not break every
+    # extractor in this plugin (ydl, invidious, live-channel), only the
+    # explicitly opt-in "pytube" backend, which raises a clear error below
+    # if it is actually used without a compatible tutubo version.
+    from tutubo.pytube import YouTube
+except ImportError:
+    YouTube = None
 
 
 class YoutubeBackend(str, enum.Enum):
@@ -386,6 +395,12 @@ class OCPPytubeExtractor(OCPYoutubeExtractor):
 
     @staticmethod
     def get_pytube_stream(url, audio_only=False, best=True):
+        if YouTube is None:
+            raise RuntimeError(
+                "the 'pytube' backend requires tutubo<3.0.0 "
+                "(tutubo.pytube was removed in tutubo>=3.0.0); "
+                "use the default 'youtube-dl' backend instead"
+            )
         yt = YouTube(url)
         s = None
         if audio_only:

--- a/test/test_tutubo_compat.py
+++ b/test/test_tutubo_compat.py
@@ -1,0 +1,50 @@
+"""
+Regression test for https://github.com/OpenVoiceOS/ovos-ocp-youtube-plugin/issues/3
+
+tutubo>=3.0.0 (see renovate PR #23, bumping to tutubo v4) removed the
+`tutubo.pytube` module entirely (it was rewritten around a new innertube-based
+API). ovos_ocp_youtube_plugin imported `from tutubo.pytube import YouTube` at
+*module level*, so simply having a newer tutubo installed made the whole
+plugin fail to import - breaking every extractor (ydl, pytube, invidious,
+live-channel), not just the pytube-specific one.
+
+This test simulates "tutubo.pytube is unavailable" (as it is with tutubo v4)
+by removing it from sys.modules, and asserts the plugin still imports.
+"""
+import builtins
+import sys
+
+
+def _reload_plugin():
+    for mod in list(sys.modules):
+        if mod == "ovos_ocp_youtube_plugin" or mod.startswith("ovos_ocp_youtube_plugin."):
+            del sys.modules[mod]
+    import ovos_ocp_youtube_plugin
+    return ovos_ocp_youtube_plugin
+
+
+def _block_tutubo_pytube(monkeypatch):
+    """simulate tutubo>=3 where the `tutubo.pytube` submodule no longer
+    exists, WITHOUT breaking tutubo's own (unrelated) internal imports."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tutubo.pytube" and (fromlist is None or "YouTube" in (fromlist or ())):
+            raise ModuleNotFoundError("No module named 'tutubo.pytube'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_import_survives_missing_tutubo_pytube(monkeypatch):
+    _block_tutubo_pytube(monkeypatch)
+    mod = _reload_plugin()
+    assert mod.OCPYoutubeExtractor is not None
+
+
+def test_ydl_extractor_still_usable_without_pytube(monkeypatch):
+    # the default (ydl) backend must not depend on tutubo.pytube being importable
+    _block_tutubo_pytube(monkeypatch)
+    mod = _reload_plugin()
+    ex = mod.OCPYoutubeExtractor()
+    assert ex.ydl is not None


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This fixes #3. Testing live against a real YouTube URL in a throwaway venv showed that extraction actually works fine today with the current tutubo pin and current yt-dlp, using the default backend — the original symptom in #3 doesn't reproduce anymore, likely because yt-dlp itself has been updated since the issue was filed, not because of anything in this plugin.

But testing against the newer tutubo version that a pending renovate PR (#23) would bump to showed the plugin fails to import at all. tutubo 3.0 and up rewrote its internals and dropped the pytube submodule entirely, and since this plugin imported from tutubo.pytube at module load time, installing the newer tutubo broke every extractor in the plugin, not just the optional pytube backend. So renovate PR #23 should not be merged as-is — it would break the plugin outright. This PR is the prerequisite: once it's in, #23 can be merged safely, since tutubo v4 works fine for the default backend.

The fix makes the tutubo.pytube import lazy and optional, with a clear error raised only if someone explicitly selects the pytube backend without a compatible tutubo version installed. Two new tests simulate tutubo.pytube being unimportable and confirm the plugin still imports and the default backend still works; they fail against the old code, which crashes at import time, and pass after the fix. Full suite: 10 of 10 passed, tested against both the old pinned tutubo and the newer 4.x version. A live round trip after the fix, with tutubo 4.0 installed, confirmed extraction still returns a real playable stream URL.
